### PR TITLE
Fix unneeded broken curl_exec (Unknown Error with Visual Editor)

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -87,7 +87,6 @@ class DiscordUtils {
 				curl_setopt( $c_handlers[$value], CURLOPT_TIMEOUT, 20 ); // Do not allow cURL to run for a long time
 				curl_setopt( $c_handlers[$value], CURLOPT_USERAGENT, 'mw-discord/1.0 (github.com/jaydenkieran)' ); // Add a unique user agent
 				curl_multi_add_handle( $mh, $c_handlers[$value] );
-				$response = curl_exec( $ch );
 			}
 
 			$running = null;


### PR DESCRIPTION
Hello. Great extension! But I found out some issue.

You don't really need to call curl_exec, because you use curl_multi. It works perfectly without it.
And even if you need to call curl_exec (for some reason), I believe it's broken as extension calls it for undefined variable ```$ch```, which should be ```$c_handlers[$value]```.

This also cause some nasty error with Visual Editor extension on page save. So you need to accept this PR (which removes curl_exec call entirely) or fix the curl_exec argument.