### PR TITLE
default to revision size for diff size

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -152,6 +152,9 @@ class DiscordUtils {
 				$size .= wfMessage( 'discord-size', sprintf( "%+d", $revision->getSize() - $previous->getSize() ) )->text();
 			}
 		}
+		if ( $size == '' ) {
+			$size .= wfMessage( 'discord-size', sprintf( "%d", $revision->getSize() ) )->text();
+		}
 		$text = wfMessage( 'discord-revisionlinks', $diff, $minor, $size )->text();
 		return $text;
 	}


### PR DESCRIPTION
Certain events (primarily page creations) fail to display a diff size because there effectively is no diff (there is no previous revision to diff with); in these cases, just display the size of the current revision.