### PR TITLE
Abbreviate anyone with a name longer than 25 chars

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -157,8 +157,9 @@ class DiscordUtils {
 		if ( $user instanceof User ) {
 			$isAnon = $user->isAnon();
 			$contribs = Title::newFromText("Special:Contributions/" . $user);
+			$user_abbr = preg_replace("(.{20}).{2,}(.{3})", "$1...$2", strval($user));
 
-			$userPage = DiscordUtils::createMarkdownLink(	$user, ( $isAnon ? $contribs : $user->getUserPage() )->getFullUrl( '', '', $proto = PROTO_HTTP ) );
+			$userPage = DiscordUtils::createMarkdownLink(	$user_abbr, ( $isAnon ? $contribs : $user->getUserPage() )->getFullUrl( '', '', $proto = PROTO_HTTP ) );
 			$userTalk = DiscordUtils::createMarkdownLink( wfMessage( 'discord-talk' )->text(), $user->getTalkPage()->getFullUrl( '', '', $proto = PROTO_HTTP ) );
 			$userContribs = DiscordUtils::createMarkdownLink( wfMessage( 'discord-contribs' )->text(), $contribs->getFullURL( '', '', $proto = PROTO_HTTP ) );
 			$text = wfMessage( 'discord-userlinks', $userPage, $userTalk, $userContribs )->text();	


### PR DESCRIPTION
Any username of 25 or more characters will be abbreviated to the first 20 characters, then `...`, and then the last three. This is especially helpful for RC stalkers with discord taking up only half their screen.

Different ways to abbreviate names would be possible by changing the regex pattern's numbers, or the resulting string.