### PR TITLE
Fix hook name

### DIFF
--- a/src/DiscordHooks.php
+++ b/src/DiscordHooks.php
@@ -173,7 +173,7 @@ class DiscordHooks {
 	 */
 	public static function onPageMoveComplete( LinkTarget $old, LinkTarget $new, UserIdentity $userIdentity, int $pageid, int $redirid, string $reason, RevisionRecord $revision ) {
 		global $wgDiscordNoBots;
-		$hookName = 'TitleMoveComplete';
+		$hookName = 'PageMoveComplete';
         $user = MediaWikiServices::getInstance()->getUserFactory()->newFromUserIdentity( $userIdentity );
 
 		if ( DiscordUtils::isDisabled( $hookName, $old->getNamespace(), $user ) ) {


### PR DESCRIPTION
Similarly to #70, the `$hookName` variable in the `PageMoveComplete` hook was still using the old hook name, which emitted warnings and showed no icon for page move messages.