### PR TITLE
Fix error on new version MediaWiki

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -2,6 +2,7 @@
 
 use MediaWiki\MediaWikiServices;
 use MediaWiki\User\UserIdentity;
+use MediaWiki\Title\Title;
 
 class DiscordUtils {
 	/**


### PR DESCRIPTION
Media wiki 1.39+ now use "use MediaWiki\Title\Title;" to get Title without it you can't upload new file image on wiki bc you get error of title

Error without it on new version: 
` [3fb7784b857a694fdbdca014] Caught exception of type Error`

`
from /wiki/extensions/Discord/src/Utils.php(179)
#0 /wiki/extensions/Discord/src/DiscordHooks.php(312): DiscordUtils::createUserLinks()
#1 /wiki/includes/HookContainer/HookContainer.php(134): DiscordHooks::onUploadComplete()
#2 /wiki/includes/HookContainer/HookRunner.php(4688): MediaWiki\HookContainer\HookContainer->run()
#3 /wiki/includes/upload/UploadBase.php(883): MediaWiki\HookContainer\HookRunner->onUploadComplete()
#4 /wiki/includes/specials/SpecialUpload.php(840): UploadBase->performUpload()
#5 /wiki/includes/specials/SpecialUpload.php(286): MediaWiki\Specials\SpecialUpload->processUpload()
#6 /wiki/includes/specialpage/SpecialPage.php(711): MediaWiki\Specials\SpecialUpload->execute()
#7 /wiki/includes/specialpage/SpecialPageFactory.php(1729): MediaWiki\SpecialPage\SpecialPage->run()
#8 /wiki/includes/actions/ActionEntryPoint.php(499): MediaWiki\SpecialPage\SpecialPageFactory->executePath()
#9 /wiki/includes/actions/ActionEntryPoint.php(143): MediaWiki\Actions\ActionEntryPoint->performRequest()
#10 /wiki/includes/MediaWikiEntryPoint.php(184): MediaWiki\Actions\ActionEntryPoint->execute()
#11 /wiki/index.php(44): MediaWiki\MediaWikiEntryPoint->run()
#12 {main}
`