### PR TITLE
Fix TypeError when creating an IP range block

### DIFF
--- a/src/DiscordUtils.php
+++ b/src/DiscordUtils.php
@@ -78,10 +78,10 @@ class DiscordUtils {
 
 	/**
 	 * Creates links for a specific MediaWiki User object
-	 * @param User|UserIdentity $user
+	 * @param User|UserIdentity|string $user
 	 * @return string
 	 */
-	public static function createUserLinks( User|UserIdentity $user ): string {
+	public static function createUserLinks( User|UserIdentity|string $user ): string {
 		global $wgDiscordMaxCharsUsernames;
 
 		if ( $user instanceof UserIdentity ) {


### PR DESCRIPTION
Fixes `TypeError: MediaWiki\Extension\Discord\DiscordUtils::createUserLinks(): Argument #1 ($user) must be of type MediaWiki\User\User|MediaWiki\User\UserIdentity, string given, called in /srv/mediawiki/extensions/Discord/src/DiscordHooks.php on line 339`  when creating an IP range block, e.g. 192.168.0.0/24.